### PR TITLE
Changed so that the infer function also returns the inferred type of …

### DIFF
--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -18,6 +18,8 @@ type constr =
   | Eq of Id.t * Polynomial.t
   | Po of Polynomial.t
 
+val pp_constr : Format.formatter -> constr -> unit
+
 (** [Solver.infer ~heuristic cs] infers the type environment
     consistent with [cs].  This function returns two environments
     [tenv] and [ctenv], where [tenv] is a normal type environment and
@@ -25,7 +27,7 @@ type constr =
     true this function applies a heuristic which tries to type program
     variables as non-dimensionless as possible (see comments in
     solver.ml for more details).  [heuristic] is true by default. *)
-val infer : ?heuristic:bool -> constr list -> Tenv.t * Typ.t list
+val infer : ?heuristic:bool -> constr list -> Tenv.t * Typ.t list * (constr * Typ.t) list
 
 (** [Solver.enum_powersets ~max_degree (tenv, ctenv) typ] enumerates
     the powersets whose types are same as [typ] under the type

--- a/t/solver_test.ml
+++ b/t/solver_test.ml
@@ -28,7 +28,7 @@ let execute () =
     ; Powerset.of_list [ (x, 1); (z, 2) ], ni 3
     ]
   in
-  let tenv, _ = infer [Po p1] in
+  let tenv, _, _ = infer [Po p1] in
   print_endline ((Tenv.to_string tenv) ^ "\n");
 
   let cs =
@@ -40,7 +40,7 @@ let execute () =
                                 ; Powerset.of_list [ (dt, 1) ], ni 1 ])
     ]
   in
-  let tenv, _ = infer cs in
+  let tenv, _, _ = infer cs in
   print_endline (Tenv.to_string tenv);
 
   let aux n = Id.of_string ("aux" ^ string_of_int n) in
@@ -53,13 +53,13 @@ let execute () =
                                 ; Powerset.of_list [ (aux 5, 1); (dt, 1) ], ni 1 ])
     ]
   in
-  let tenv, _ = infer cs in
+  let tenv, _, _ = infer cs in
   print_endline (Tenv.to_string tenv);
 
   let cs = [ Po (Polynomial.of_list [ Powerset.of_list [ (x, 1) ], ni 1
                                     ; Powerset.of_list [ (x, 2) ], ni 1 ]) ]
   in
-  let tenv, ctenv = infer cs in
+  let tenv, ctenv, _ = infer cs in
   Format.(
     fprintf std_formatter "ctenv: %a@.tenv: %a@."
       (pp_print_list


### PR DESCRIPTION
…the polynomial in each constraint.

The infer function does not return the type of inferred type for passed polynomials.  This is sometimes problematic because infer eliminates all the auxiliary variables; the caller side cannot recover where these auxiliary variables were, therefore cannot recover the type of each polynomial only from the returned type environment.

I revised the function to return the list of (polynomial \* type).  I suppose this is quite awkward but it seems to work.  Any comments are welcome.
